### PR TITLE
Optimization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,3 +24,6 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+# gem "skylight", "~> 3.1"
+gem 'pghero'
+gem 'oj'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,10 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.2)
       mini_portile2 (~> 2.4.0)
+    oj (3.7.11)
     pg (1.1.4)
+    pghero (2.2.0)
+      activerecord
     puma (3.12.1)
     rack (2.0.6)
     rack-test (1.1.0)
@@ -137,7 +140,9 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   listen (>= 3.0.5, < 3.2)
+  oj
   pg (>= 0.18, < 2.0)
+  pghero
   puma (~> 3.11)
   rails (~> 5.2.3)
   tzinfo-data

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -2,6 +2,8 @@ class TripsController < ApplicationController
   def index
     @from = City.find_by_name!(params[:from])
     @to = City.find_by_name!(params[:to])
-    @trips = Trip.where(from: @from, to: @to).order(:start_time)
+    @trips = Trip.where(from: @from, to: @to)
+                 .eager_load(bus: :services)
+                 .order(:start_time)
   end
 end

--- a/app/views/trips/_services.html.erb
+++ b/app/views/trips/_services.html.erb
@@ -1,6 +1,8 @@
 <li>Сервисы в автобусе:</li>
 <ul>
   <% services.each do |service| %>
-    <%= render "service", service: service %>
+    <% cache(service) do %>
+      <%= render "service", service: service %>
+    <% end %>
   <% end %>
 </ul>

--- a/app/views/trips/index.html.erb
+++ b/app/views/trips/index.html.erb
@@ -7,10 +7,18 @@
 
 <% @trips.each do |trip| %>
   <ul>
-    <%= render "trip", trip: trip %>
-    <% if trip.bus.services.present? %>
-      <%= render "services", services: trip.bus.services %>
-    <% end %>
+    <li><%= "Отправление: #{trip.start_time}" %></li>
+    <li><%= "Прибытие: #{(Time.parse(trip.start_time) + trip.duration_minutes.minutes).strftime('%H:%M')}" %></li>
+    <li><%= "В пути: #{trip.duration_minutes / 60}ч. #{trip.duration_minutes % 60}мин." %></li>
+    <li><%= "Цена: #{trip.price_cents / 100}р. #{trip.price_cents % 100}коп." %></li>
+    <li><%= "Автобус: #{trip.bus.model} №#{trip.bus.number}" %></li>
+    <% next unless trip.bus.services.present? %>
+    <li>Сервисы в автобусе:</li>
+    <ul>
+      <% trip.bus.services.each do |service| %>
+        <li><%= "#{service.name}" %></li>
+      <% end %>
+    </ul>
   </ul>
-  <%= render "delimiter" %>
+  ====================================================
 <% end %>

--- a/bin/feedback-loop.rb
+++ b/bin/feedback-loop.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+require 'benchmark'
+require 'fileutils'
+include FileUtils
+
+FILES = %w[
+  example.json
+  small.json
+  medium.json
+  large.json
+].freeze
+
+APP_ROOT = File.expand_path('..', __dir__)
+
+def system!(*args)
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
+
+chdir APP_ROOT do
+  FILES.each do |file|
+    result = Benchmark.measure do
+      puts "\n== Loading data from fixtures/#{file} =="
+      system! "bin/rake reload_json[fixtures/#{file}]"
+    end
+
+    puts result
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,7 @@ module Task4
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    # config.skylight.environments += ["development"]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  mount PgHero::Engine, at: "pghero"
   get "/" => "statistics#index"
   get "автобусы/:from/:to" => "trips#index"
 end

--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -1,3 +1,3 @@
 ---
 # The authentication token for the application.
-authentication: DcUn7LxoVTsGHsGvnPXXA8yjoujr8NC-P0IW3m5LruA
+# authentication: DcUn7LxoVTsGHsGvnPXXA8yjoujr8NC-P0IW3m5LruA

--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -1,0 +1,3 @@
+---
+# The authentication token for the application.
+authentication: DcUn7LxoVTsGHsGvnPXXA8yjoujr8NC-P0IW3m5LruA

--- a/db/migrate/20190402073803_add_indexes.rb
+++ b/db/migrate/20190402073803_add_indexes.rb
@@ -1,0 +1,10 @@
+class AddIndexes < ActiveRecord::Migration[5.2]
+  def change
+
+    add_index :cities, %i[id name]
+    add_index :trips, %i[id from_id to_id]
+    add_index :buses, %i[id number model]
+    add_index :buses_services, %i[id bus_id service_id]
+    add_index :services, %i[id name]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_30_193044) do
+ActiveRecord::Schema.define(version: 2019_04_02_073803) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -19,19 +19,23 @@ ActiveRecord::Schema.define(version: 2019_03_30_193044) do
   create_table "buses", force: :cascade do |t|
     t.string "number"
     t.string "model"
+    t.index ["id", "number", "model"], name: "index_buses_on_id_and_number_and_model"
   end
 
   create_table "buses_services", force: :cascade do |t|
     t.integer "bus_id"
     t.integer "service_id"
+    t.index ["id", "bus_id", "service_id"], name: "index_buses_services_on_id_and_bus_id_and_service_id"
   end
 
   create_table "cities", force: :cascade do |t|
     t.string "name"
+    t.index ["id", "name"], name: "index_cities_on_id_and_name"
   end
 
   create_table "services", force: :cascade do |t|
     t.string "name"
+    t.index ["id", "name"], name: "index_services_on_id_and_name"
   end
 
   create_table "trips", force: :cascade do |t|
@@ -41,6 +45,7 @@ ActiveRecord::Schema.define(version: 2019_03_30_193044) do
     t.integer "duration_minutes"
     t.integer "price_cents"
     t.integer "bus_id"
+    t.index ["id", "from_id", "to_id"], name: "index_trips_on_id_and_from_id_and_to_id"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,6 +13,7 @@
 ActiveRecord::Schema.define(version: 2019_03_30_193044) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "buses", force: :cascade do |t|

--- a/lib/tasks/utils.rake
+++ b/lib/tasks/utils.rake
@@ -1,7 +1,7 @@
-# Наивная загрузка данных из json-файла в БД
-# rake reload_json[fixtures/small.json]
+require 'oj'
+
 task :reload_json, [:file_name] => :environment do |_task, args|
-  json = JSON.parse(File.read(args.file_name))
+  json = Oj.load(File.read(args.file_name))
 
   ActiveRecord::Base.transaction do
     City.delete_all
@@ -10,25 +10,67 @@ task :reload_json, [:file_name] => :environment do |_task, args|
     Trip.delete_all
     ActiveRecord::Base.connection.execute('delete from buses_services;')
 
-    json.each do |trip|
-      from = City.find_or_create_by(name: trip['from'])
-      to = City.find_or_create_by(name: trip['to'])
-      services = []
-      trip['bus']['services'].each do |service|
-        s = Service.find_or_create_by(name: service)
-        services << s
-      end
-      bus = Bus.find_or_create_by(number: trip['bus']['number'])
-      bus.update(model: trip['bus']['model'], services: services)
+    ActiveRecord::Base.connection.tables.each do |t|
+      ActiveRecord::Base.connection.reset_pk_sequence!(t)
+    end
 
-      Trip.create!(
-        from: from,
-        to: to,
-        bus: bus,
-        start_time: trip['start_time'],
-        duration_minutes: trip['duration_minutes'],
-        price_cents: trip['price_cents'],
+    cities = []
+    bus_array = []
+
+    json.each do |trip|
+      cities.push("('#{trip['from']}')")
+      cities.push("('#{trip['to']}')")
+      bus_array.push(trip['bus'])
+    end
+
+    sql = "INSERT INTO cities (name) VALUES #{cities.uniq.join(', ')}"
+    ActiveRecord::Base.connection.execute(sql)
+    cities = City.pluck(:name, :id).to_h
+
+    buses = []
+    services = []
+
+    bus_array.each do |obj|
+      buses.push("(#{obj['number']}, '#{obj['model']}')")
+      obj['services'].each { |service| services.push("('#{service}')") }
+    end
+
+    sql = "INSERT INTO buses (number, model) VALUES #{buses.uniq.join(', ')}"
+    ActiveRecord::Base.connection.execute(sql)
+    buses = Bus.pluck(:id, :number, :model)
+
+    sql = "INSERT INTO services (name) VALUES #{services.uniq.join(', ')}"
+    ActiveRecord::Base.connection.execute(sql)
+
+    list_services = Service.pluck(:name, :id).to_h
+    buses_services = []
+    trips = []
+
+    json.each do |trip|
+      bus = buses.detect do |obj|
+        obj[1] == trip['bus']['number'] &&
+          obj[2] == trip['bus']['model']
+      end
+      list_services.slice(*trip['bus']['services'])
+                   .each_value do |service_id|
+        buses_services.push("(#{bus[0]}, #{service_id})")
+      end
+      trips.push(
+        "(
+        #{cities[trip['from']]},
+        #{cities[trip['to']]},
+        #{bus[0]},
+        '#{trip['start_time']}',
+        #{trip['duration_minutes']},
+        #{trip['price_cents']}
+        )"
       )
     end
+
+    sql = "INSERT INTO buses_services (bus_id, service_id) VALUES #{buses_services.uniq.join(', ')}"
+    ActiveRecord::Base.connection.execute(sql)
+
+    sql = "INSERT INTO trips (from_id, to_id, bus_id, start_time, duration_minutes, price_cents) VALUES #{trips.join(', ')}"
+    ActiveRecord::Base.connection.execute(sql)
   end
 end


### PR DESCRIPTION
### Актуальная проблема

При выполнении `rake reload_json[fixtures/large.json]` в базу данных загружаются данные о рейсах из файла `fixtures/large.json` в течении очень длительного времени

Для тестирования я подготовил `feedback-loop`, который позволял оценить время выполнения загрузки. Вот время загрузки данных до оптимизации.

``` session
== Loading data from fixtures/example.json ==
  0.000201   0.000954   1.162049 (  1.259974)

== Loading data from fixtures/small.json ==
  0.000113   0.000632   8.549043 (  9.639957)

== Loading data from fixtures/medium.json ==
  0.000118   0.000646  55.309189 ( 66.940845)

== Loading data from fixtures/large.json ==
  0.000129   0.000615 553.928788 (684.994141)
```

###  Оптимизация 1

После анализа исходного кода файла `lib/tasks/utils.rake`  я обнаружил большое количество однотипных запросов к базе данных. С помощью инструмента `pghero` было видно, что в течении загрузки создавалось огромное количество запросов в базу данных.

Ниже список самых частых запросов в базу данных, каждый из них выполнялся очень быстро, но количество запросов в течении загрузки данных не было правильным.
`SELECT  "cities".* FROM "cities" WHERE "cities"."name" = $1 LIMIT $2`
`SELECT  "buses".* FROM "buses" WHERE "buses"."number" = $1 AND "buses"."model" = $2 LIMIT $3` 
`SELECT  "services".* FROM "services" WHERE "services"."name" = $1 LIMIT $2`

Я заменил полностью весь код для загрузки данных. Вместо вставки в базу данных по одной записи, я использовал метод вставки нескольких записей.

Таким образом сначала создавались все подготовительные таблицы (buses, services, cities) и после этого создавались записи  для таблицы trips

Для каждого раза, после удаления всех записей из таблицы, я добавил сброс нумерации id для каждой из таблиц `ActiveRecord::Base.connection.reset_pk_sequence!(t)`
Это небольшая оптимизация позволит избежать проблем в будущем.

После оптимизации, мне удалось достичь большого прироста при загрузке данных.

```session
== Loading data from fixtures/example.json ==
  0.000208   0.000810   1.018404 (  1.138066)

== Loading data from fixtures/small.json ==
  0.000120   0.000655   1.137197 (  1.105273)

== Loading data from fixtures/medium.json ==
  0.000123   0.000612   2.094093 (  2.118166)

== Loading data from fixtures/large.json ==
  0.000120   0.000635  10.964515 ( 12.227762)
```

Время выполнения загрузки для файла `fixtures/large.json` сократилось с `684.994141` до `12.227762`.

###  Оптимизация 2

Рендеринг страницы `http://localhost:3000/автобусы/Самара/Москва` также не был оптимальным.
Проверку времени отображения я делал с помощью  `ab -n 20 -c 1 http://localhost:3000/автобусы/Самара/Москва`.
Время до оптимизации

```session
Time taken for tests:   1.533 seconds
Complete requests:      20
Failed requests:        0
Non-2xx responses:      20
Total transferred:      1280340 bytes
HTML transferred:       1275500 bytes
Requests per second:    13.05 [#/sec] (mean)
Time per request:       76.633 [ms] (mean)
Time per request:       76.633 [ms] (mean, across all concurrent requests)
Transfer rate:          815.79 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:    61   76  24.1     72     169
Waiting:       61   76  24.1     72     169
Total:         61   77  24.1     72     169

Percentage of the requests served within a certain time (ms)
  50%     72
  66%     73
  75%     74
  80%     90
  90%     96
  95%    169
  98%    169
  99%    169
 100%    169 (longest request)
```

При просмотре исходного кода я нашел две проблемы, которые я оптимизировал.

#### 1 проблема - N+1 запросы.

При выводе страницы отображалась информация из связанных моделей. Для оптимизации я использовал `eager_load` для запроса для `Trip`

#### 2 проблема - рендер partial

Так как вывод информации достаточно простой, самое правильное решение избавиться от рендеринга `partial's` и выводить сразу все в цикле. 

После оптимизации

``` session
Time taken for tests:   1.251 seconds
Complete requests:      20
Failed requests:        0
Non-2xx responses:      20
Total transferred:      1274020 bytes
HTML transferred:       1269180 bytes
Requests per second:    15.98 [#/sec] (mean)
Time per request:       62.568 [ms] (mean)
Time per request:       62.568 [ms] (mean, across all concurrent requests)
Transfer rate:          994.24 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.1      0       0
Processing:    56   62  11.4     59     106
Waiting:       56   62  11.4     58     105
Total:         56   63  11.4     59     106

Percentage of the requests served within a certain time (ms)
  50%     59
  66%     59
  75%     62
  80%     63
  90%     78
  95%    106
  98%    106
  99%    106
 100%    106 (longest request)
```

Подключение кеша в моих экспериментах не дало большого прироста, хотя его также можно использовать для сокращения времени рендеринга.
